### PR TITLE
MS-360 : empêcher le merge dans master si le précédent commit de master n'a pas de tag

### DIFF
--- a/workflows/check-tag.yml
+++ b/workflows/check-tag.yml
@@ -1,0 +1,26 @@
+name: "Ensure previous version is tagged"
+
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+jobs:
+  check-previous-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Fetch all tags
+        run: git fetch --tags
+
+      - name: Check if previous commit is tagged
+        run: |
+          # Récupérer le dernier commit sur master
+          PREVIOUS_COMMIT=$(git rev-parse origin/master^)
+          # Vérifier si ce commit est tagué
+          if [ -z "$(git tag --points-at $PREVIOUS_COMMIT)" ]; then
+            echo "Error: The previous commit on master is not tagged!"
+            exit 1
+          fi


### PR DESCRIPTION
# Description
Afin de pouvoir faire un rollback facilement, il faut s'assurer que la master a précédemment été taguée

# Types de changements
- [x] Nouvelle fonctionnalité

# Changements faits
Ajout d'une Github Action bloquant le merge si aucun tag n'est trouvé sur le dernier commit dans master
